### PR TITLE
Completed Change Password, Forgot Password, and Reset Password features

### DIFF
--- a/src/Application/FitnessTracker.Application/DTOs/Accounts/ChangePasswordDto.cs
+++ b/src/Application/FitnessTracker.Application/DTOs/Accounts/ChangePasswordDto.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace FitnessTracker.Application.DTOs.Account
+{
+    public class ChangePasswordDto
+    {
+        [Required]
+        [DataType(DataType.Password)]
+        [Display(Name = "Current password")]
+        public string CurrentPassword { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 8)] 
+        [DataType(DataType.Password)]
+        [Display(Name = "New password")]
+        public string NewPassword { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm new password")]
+        [Compare("NewPassword", ErrorMessage = "The new password and confirmation password do not match.")]
+        public string ConfirmNewPassword { get; set; } = string.Empty;
+    }
+}

--- a/src/Application/FitnessTracker.Application/DTOs/Accounts/ForgotPasswordDto.cs
+++ b/src/Application/FitnessTracker.Application/DTOs/Accounts/ForgotPasswordDto.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace FitnessTracker.Application.DTOs.Account
+{
+    public class ForgotPasswordDto
+    {
+        [Required(ErrorMessage = "Email address is required.")]
+        [EmailAddress(ErrorMessage = "Please enter a valid email address.")]
+        [Display(Name = "Email Address")]
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/src/Application/FitnessTracker.Application/DTOs/Accounts/ResetPasswordDto.cs
+++ b/src/Application/FitnessTracker.Application/DTOs/Accounts/ResetPasswordDto.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace FitnessTracker.Application.DTOs.Account
+{
+    public class ResetPasswordDto
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty; 
+
+        [Required]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 8)]
+        [DataType(DataType.Password)]
+        [Display(Name = "New Password")]
+        public string Password { get; set; } = string.Empty;
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm New Password")]
+        [Compare("Password", ErrorMessage = "The new password and confirmation password do not match.")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+
+        [Required]
+        public string Token { get; set; } = string.Empty; 
+    }
+}

--- a/src/Application/FitnessTracker.Application/Interfaces/IUserService.cs
+++ b/src/Application/FitnessTracker.Application/Interfaces/IUserService.cs
@@ -1,4 +1,5 @@
-using FitnessTracker.Application.Common; 
+using FitnessTracker.Application.Common;
+using FitnessTracker.Application.DTOs.Account;
 using FitnessTracker.Application.DTOs.Accounts; 
 using FitnessTracker.Domain.Entities;      
 
@@ -10,8 +11,14 @@ namespace FitnessTracker.Application.Interfaces
       
         Task<Result<(ApplicationUser User, string ConfirmationToken)>> RegisterUserAsync(UserRegistrationDto dto);
 
-        Task<LoginResponseDto> GenerateLoginResponseAsync(ApplicationUser user); // Stays the same
+        Task<LoginResponseDto> GenerateLoginResponseAsync(ApplicationUser user);
 
         Task<Result<(ApplicationUser User, string ConfirmationToken)>> PrepareResendConfirmationTokenAsync(string email);
+        
+        Task<Result> ChangePasswordAsync(string userId, ChangePasswordDto dto);
+        
+        Task<Result<(ApplicationUser User, string ResetToken)>> GeneratePasswordResetTokenAsync(string email);
+        
+        Task<Result> ResetPasswordAsync(ResetPasswordDto dto);
     }
 }

--- a/src/Application/FitnessTracker.Application/Services/UserService.cs
+++ b/src/Application/FitnessTracker.Application/Services/UserService.cs
@@ -1,4 +1,5 @@
 using FitnessTracker.Application.Common;
+using FitnessTracker.Application.DTOs.Account;
 using FitnessTracker.Application.DTOs.Accounts;
 using FitnessTracker.Application.Interfaces;
 using FitnessTracker.Domain.Entities;
@@ -33,15 +34,11 @@ namespace FitnessTracker.Application.Services
 
             var user = new ApplicationUser
             {
-                UserName = dto.Email,
-                Email = dto.Email,
-                FirstName = dto.FirstName,
-                LastName = dto.LastName,
-                EmailConfirmed = false
+                UserName = dto.Email, Email = dto.Email, FirstName = dto.FirstName,
+                LastName = dto.LastName, EmailConfirmed = false
             };
 
             var createResult = await _userManager.CreateAsync(user, dto.Password);
-
             if (!createResult.Succeeded)
             {
                 var errorMessages = string.Join(" ", createResult.Errors.Select(e => e.Description));
@@ -56,7 +53,6 @@ namespace FitnessTracker.Application.Services
             await _userManager.AddToRoleAsync(user, "User"); 
 
             var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
-            
             return Result<(ApplicationUser User, string ConfirmationToken)>.Success((user, token));
         }
 
@@ -64,7 +60,6 @@ namespace FitnessTracker.Application.Services
         {
             var tokenDetails = await _jwtTokenGenerator.GenerateTokenDetailsAsync(user);
             var userRoles = await _userManager.GetRolesAsync(user);
-
             return new LoginResponseDto
             {
                 IsSuccess = true, Message = "Login successful.", Token = tokenDetails.Token,
@@ -72,29 +67,73 @@ namespace FitnessTracker.Application.Services
                 FirstName = user.FirstName, LastName = user.LastName, Roles = userRoles ?? new List<string>()
             };
         }
+        
+        public async Task<Result> ChangePasswordAsync(string userId, ChangePasswordDto dto)
+        {
+            var user = await _userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                return Result.NotFound("User not found for password change.");
+            }
+
+            var changePasswordResult = await _userManager.ChangePasswordAsync(user, dto.CurrentPassword, dto.NewPassword);
+            if (changePasswordResult.Succeeded)
+            {
+                await _userManager.UpdateSecurityStampAsync(user);
+                return Result.Success();
+            }
+            
+            var errorMessages = string.Join(" ", changePasswordResult.Errors.Select(e => e.Description));
+            if (changePasswordResult.Errors.Any(e => e.Code == "PasswordMismatch"))
+            {
+                return Result.ValidationFailed("The current password entered is incorrect.", "PasswordMismatch");
+            }
+            return Result.ValidationFailed(errorMessages, "PasswordChangeFailed");
+        }
+
+        public async Task<Result<(ApplicationUser User, string ResetToken)>> GeneratePasswordResetTokenAsync(string email)
+        {
+            var user = await _userManager.FindByEmailAsync(email);
+            if (user == null)
+            {
+                return Result<(ApplicationUser User, string ResetToken)>.NotFound("User with this email not found.");
+            }
+            var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+            return Result<(ApplicationUser User, string ResetToken)>.Success((user, token));
+        }
+        
+        public async Task<Result> ResetPasswordAsync(ResetPasswordDto dto)
+        {
+            var user = await _userManager.FindByEmailAsync(dto.Email);
+            if (user == null)
+            {
+                return Result.NotFound("User not found for password reset.");
+            }
+            var resetResult = await _userManager.ResetPasswordAsync(user, dto.Token, dto.Password);
+            if (resetResult.Succeeded)
+            {
+                await _userManager.UpdateSecurityStampAsync(user);
+                return Result.Success();
+            }
+            var errorMessages = string.Join(" ", resetResult.Errors.Select(e => e.Description));
+            return Result.ValidationFailed(errorMessages, resetResult.Errors.FirstOrDefault()?.Code ?? "PasswordResetFailed");
+        }
 
         public async Task<Result<(ApplicationUser User, string ConfirmationToken)>> PrepareResendConfirmationTokenAsync(string email)
         {
             var user = await _userManager.FindByEmailAsync(email);
-
             if (user == null)
             {
-                return Result<(ApplicationUser User, string ConfirmationToken)>.NotFound(
-                    "User not found. A generic message will be shown to the client for privacy.");
+                return Result<(ApplicationUser User, string ConfirmationToken)>.NotFound("User not found.");
             }
-            
             if (string.IsNullOrEmpty(user.Email)) 
             {
-                 return Result<(ApplicationUser User, string ConfirmationToken)>.Failure(
-                     "User account has invalid email data.", ErrorType.Unexpected);
+                 return Result<(ApplicationUser User, string ConfirmationToken)>.Failure("User account has invalid email data.", ErrorType.Unexpected);
             }
-
             if (user.EmailConfirmed)
             {
-                return Result<(ApplicationUser User, string ConfirmationToken)>.Conflict(
-                    "This email address has already been confirmed.", "EmailAlreadyConfirmed");
+                return Result<(ApplicationUser User, string ConfirmationToken)>.Conflict("This email address has already been confirmed.", "EmailAlreadyConfirmed");
             }
-
             var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
             return Result<(ApplicationUser User, string ConfirmationToken)>.Success((user, token));
         }

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Account/ForgotPassword.cshtml
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Account/ForgotPassword.cshtml
@@ -1,0 +1,38 @@
+@page
+@model FitnessTracker.WebUI.Pages.Account.ForgotPasswordModel
+@{
+    ViewData["Title"] = "Forgot your password?";
+    Layout = "_Layout";
+}
+
+<h2>@ViewData["Title"]</h2>
+<h4>Enter your email.</h4>
+<hr />
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    <div class="alert alert-info" role="alert">
+        @Model.StatusMessage
+    </div>
+}
+
+<div class="row">
+    <div class="col-md-4">
+        <form method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                <label asp-for="Input.Email" class="form-label"></label>
+                <span asp-validation-for="Input.Email" class="text-danger"></span>
+            </div>
+            <button type="submit" class="w-100 btn btn-lg btn-primary">Submit</button>
+        </form>
+        <div class="mt-3">
+            <p><a asp-page="./Login">Back to Login</a></p>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Account/ForgotPassword.cshtml.cs
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,0 +1,79 @@
+using FitnessTracker.Application.DTOs.Account;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Text.Json;
+
+namespace FitnessTracker.WebUI.Pages.Account
+{
+    [AllowAnonymous]
+    public class ForgotPasswordModel : PageModel
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public ForgotPasswordModel(IHttpClientFactory httpClientFactory )
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        [BindProperty]
+        public ForgotPasswordDto Input { get; set; } = new ForgotPasswordDto();
+
+        public string? StatusMessage { get; private set; }
+
+        private class ApiResponseDto
+        {
+            public string? Message { get; set; }
+        }
+
+        public void OnGet()
+        {
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var apiClient = _httpClientFactory.CreateClient("ApiClient");
+            string privacyPreservingMessage = "If an account with that email address exists, a password reset link has been sent. Please check your inbox (and spam folder).";
+
+            try
+            {
+                HttpResponseMessage response = await apiClient.PostAsJsonAsync("api/account/forgot-password", Input);
+                
+                if (response.IsSuccessStatusCode)
+                {
+                    try
+                    {
+                        var apiResponse = await response.Content.ReadFromJsonAsync<ApiResponseDto>(new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                        StatusMessage = apiResponse?.Message ?? privacyPreservingMessage;
+                    }
+                    catch (JsonException) 
+                    {
+                        StatusMessage = privacyPreservingMessage;
+                    }
+                }
+                else 
+                {
+                    StatusMessage = privacyPreservingMessage;
+                }
+            }
+            catch (HttpRequestException)
+            {
+                StatusMessage = "Could not connect to the server. Please try again later.";
+            }
+            catch (JsonException) 
+            {
+                StatusMessage = privacyPreservingMessage; 
+            }
+            catch (Exception) 
+            {
+                StatusMessage = "An unexpected error occurred processing your request. Please try again.";
+            }
+            return Page();
+        }
+    }
+}

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Account/Login.cshtml
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Account/Login.cshtml
@@ -40,7 +40,9 @@
                 }
 
                 <div class="mt-3">
-                 
+                    <p>
+                        <a id="forgot-password" asp-page="./ForgotPassword">Forgot your password?</a>
+                    </p>
                     <p>
                         <a asp-page="./Register" asp-route-returnUrl="@Model.ReturnUrl">Register as a new user</a>
                     </p>

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Account/Manage/ChangePassword.cshtml
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Account/Manage/ChangePassword.cshtml
@@ -1,0 +1,44 @@
+@page
+@model FitnessTracker.WebUI.Pages.Account.Manage.ChangePasswordModel
+@{
+    ViewData["Title"] = "Change Password";
+    Layout = "_Layout";
+}
+
+<h4>@ViewData["Title"]</h4>
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    var statusMessageClass = Model.IsSuccess ? "alert-success" : "alert-danger";
+    <div class="alert @statusMessageClass" role="alert">
+        @Model.StatusMessage
+    </div>
+}
+
+<div class="row">
+    <div class="col-md-6">
+        <form id="change-password-form" method="post">
+            <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.CurrentPassword" class="form-control" autocomplete="current-password" aria-required="true" placeholder="Please enter your current password."/>
+                <label asp-for="Input.CurrentPassword" class="form-label"></label>
+                <span asp-validation-for="Input.CurrentPassword" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.NewPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please enter your new password."/>
+                <label asp-for="Input.NewPassword" class="form-label"></label>
+                <span asp-validation-for="Input.NewPassword" class="text-danger"></span>
+            </div>
+            <div class="form-floating mb-3">
+                <input asp-for="Input.ConfirmNewPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please confirm your new password."/>
+                <label asp-for="Input.ConfirmNewPassword" class="form-label"></label>
+                <span asp-validation-for="Input.ConfirmNewPassword" class="text-danger"></span>
+            </div>
+            <button type="submit" class="w-100 btn btn-lg btn-primary">Update password</button>
+        </form>
+    </div>
+</div>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Account/Manage/ChangePassword.cshtml.cs
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Account/Manage/ChangePassword.cshtml.cs
@@ -1,0 +1,96 @@
+using FitnessTracker.Application.DTOs.Account;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace FitnessTracker.WebUI.Pages.Account.Manage
+{
+    [Authorize]
+    public class ChangePasswordModel : PageModel
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public ChangePasswordModel(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        [BindProperty]
+        public ChangePasswordDto Input { get; set; } = new ChangePasswordDto();
+
+        [TempData]
+        public string? StatusMessage { get; set; }
+        public bool IsSuccess { get; set; }
+
+        private class ApiResponseDto { 
+            public string? Message { get; set; }
+            public string? Code { get; set; }
+        }
+
+        public void OnGet() { }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            IsSuccess = false;
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var apiClient = _httpClientFactory.CreateClient("ApiClient");
+
+            var token = Request.Cookies["api_auth_token"];
+
+            if (string.IsNullOrEmpty(token))
+            {
+                StatusMessage = "Authentication token is missing. Please log in again.";
+                ModelState.AddModelError(string.Empty, StatusMessage);
+                return Page(); 
+            }
+            
+            apiClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+
+            try
+            {
+                HttpResponseMessage response = await apiClient.PostAsJsonAsync("api/account/change-password", Input);
+                string responseContentString = await response.Content.ReadAsStringAsync();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    StatusMessage = "Your password has been changed successfully.";
+                    IsSuccess = true;
+                    return RedirectToPage();
+                }
+                else
+                {
+                    string apiErrorMessage = "Failed to change password. Please check your input and try again.";
+                    if (!string.IsNullOrWhiteSpace(responseContentString)) {
+                        try
+                        {
+                            var errorDto = JsonSerializer.Deserialize<ApiResponseDto>(responseContentString, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                            if (!string.IsNullOrEmpty(errorDto?.Message)) { apiErrorMessage = errorDto.Message; }
+                        }
+                        catch (JsonException) { }
+                    }
+                    StatusMessage = apiErrorMessage;
+                    ModelState.AddModelError(string.Empty, apiErrorMessage);
+                    return Page();
+                }
+            }
+            catch (HttpRequestException)
+            {
+                StatusMessage = "Could not connect to the server to change your password. Please try again later.";
+                ModelState.AddModelError(string.Empty, StatusMessage);
+                return Page();
+            }
+            catch (Exception)
+            {
+                StatusMessage = "An unexpected error occurred while trying to change your password. Please try again.";
+                ModelState.AddModelError(string.Empty, StatusMessage);
+                return Page();
+            }
+        }
+    }
+}

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Account/ResetPassword.cshtml
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Account/ResetPassword.cshtml
@@ -1,0 +1,58 @@
+@page
+@model FitnessTracker.WebUI.Pages.Account.ResetPasswordModel
+@{
+    ViewData["Title"] = "Reset password";
+    Layout = "_Layout";
+}
+
+<h2>@ViewData["Title"]</h2>
+<h4>Reset your password.</h4>
+<hr />
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+    var statusMessageClass = Model.IsSuccess ? "alert-success" : "alert-danger";
+    <div class="alert @statusMessageClass" role="alert">
+        @Model.StatusMessage
+    </div>
+}
+
+@if (!Model.IsSuccess) 
+{
+    <div class="row">
+        <div class="col-md-4">
+            <form method="post">
+                <div asp-validation-summary="ModelOnly" class="text-danger" role="alert"></div>
+                <input asp-for="Input.Token" type="hidden" /> 
+                <input asp-for="Input.Email" type="hidden" /> 
+                
+                <div class="form-floating mb-3">
+                    <input asp-for="Input.Email" class="form-control" readonly /> 
+                    <label asp-for="Input.Email" class="form-label"></label>
+                </div>
+                <div class="form-floating mb-3">
+                    <input asp-for="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please enter your new password."/>
+                    <label asp-for="Input.Password" class="form-label"></label>
+                    <span asp-validation-for="Input.Password" class="text-danger"></span>
+                </div>
+                <div class="form-floating mb-3">
+                    <input asp-for="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="Please confirm your new password."/>
+                    <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+                    <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+                </div>
+                <button type="submit" class="w-100 btn btn-lg btn-primary">Reset password</button>
+            </form>
+        </div>
+    </div>
+}
+else 
+{
+    <p>
+        Your password has been reset. Please <a asp-page="./Login">click here to log in</a>.
+    </p>
+}
+
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Account/ResetPassword.cshtml.cs
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Account/ResetPassword.cshtml.cs
@@ -1,0 +1,124 @@
+using FitnessTracker.Application.DTOs.Account; 
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.WebUtilities;
+using System.Text; 
+using System.Text.Json;
+
+namespace FitnessTracker.WebUI.Pages.Account
+{
+    [AllowAnonymous]
+    public class ResetPasswordModel : PageModel
+    {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public ResetPasswordModel(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
+        [BindProperty]
+        public ResetPasswordDto Input { get; set; } = new ResetPasswordDto();
+
+        public string? StatusMessage { get; private set; }
+        public bool IsSuccess { get; private set; }
+
+        private class ApiResponseDto
+        {
+            public string? Message { get; set; }
+        }
+
+        public IActionResult OnGet(string? token = null, string? email = null)
+        {
+            if (token == null || email == null)
+            {
+                StatusMessage = "A code and email must be supplied for password reset.";
+                IsSuccess = false;
+                return Page(); 
+            }
+            else
+            {
+                Input.Token = token; 
+                Input.Email = email;
+                return Page();
+            }
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            string decodedToken;
+            try
+            {
+                decodedToken = Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(Input.Token));
+            }
+            catch (FormatException)
+            {
+                StatusMessage = "The password reset token is invalid or corrupted.";
+                IsSuccess = false;
+                ModelState.AddModelError(string.Empty, StatusMessage);
+                return Page();
+            }
+
+            var apiRequestDto = new ResetPasswordDto
+            {
+                Email = Input.Email,
+                Password = Input.Password,
+                ConfirmPassword = Input.ConfirmPassword,
+                Token = decodedToken 
+            };
+
+            var apiClient = _httpClientFactory.CreateClient("ApiClient");
+            try
+            {
+                HttpResponseMessage response = await apiClient.PostAsJsonAsync("api/account/reset-password", apiRequestDto);
+                var responseContentString = await response.Content.ReadAsStringAsync();
+
+                if (response.IsSuccessStatusCode)
+                {
+                    StatusMessage = "Your password has been reset successfully. You can now log in.";
+                    IsSuccess = true;
+                    return Page(); 
+                }
+                else
+                {
+                    IsSuccess = false;
+                    string errorMessage = "Failed to reset password. Please try again.";
+                     if (!string.IsNullOrWhiteSpace(responseContentString)) {
+                        try
+                        {
+                            var errorDto = JsonSerializer.Deserialize<ApiResponseDto>(responseContentString, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                            if (!string.IsNullOrEmpty(errorDto?.Message))
+                            {
+                                errorMessage = errorDto.Message;
+                            }
+                        }
+                        catch (JsonException) { }
+                    }
+                    StatusMessage = errorMessage;
+                    ModelState.AddModelError(string.Empty, errorMessage);
+                    return Page();
+                }
+            }
+            catch (HttpRequestException)
+            {
+                IsSuccess = false;
+                StatusMessage = "Could not connect to the server. Please try again later.";
+                ModelState.AddModelError(string.Empty, StatusMessage);
+                return Page();
+            }
+            catch (Exception)
+            {
+                IsSuccess = false;
+                StatusMessage = "An unexpected error occurred. Please try again.";
+                ModelState.AddModelError(string.Empty, StatusMessage);
+                return Page();
+            }
+        }
+    }
+}

--- a/src/Presentation/FitnessTracker.WebUI/Pages/Shared/_LoginPartial.cshtml
+++ b/src/Presentation/FitnessTracker.WebUI/Pages/Shared/_LoginPartial.cshtml
@@ -1,6 +1,5 @@
 @using Microsoft.AspNetCore.Identity
 @using FitnessTracker.Domain.Entities
-
 @inject SignInManager<ApplicationUser> SignInManager
 @inject UserManager<ApplicationUser> UserManager
 
@@ -8,21 +7,28 @@
     @if (SignInManager.IsSignedIn(User))
     {
         <li class="nav-item">
-            <a class="nav-link text-dark" asp-page="/Account/Manage/Index" title="Manage">Hello @UserManager.GetUserName(User)!</a>
+            @{
+                var user = await UserManager.GetUserAsync(User);
+                var userName = user?.FirstName ?? User.Identity?.Name;
+            }
+            <a id="manage" class="nav-link text-dark" asp-area="Identity" asp-page="/Account/Manage/Index" title="Manage">Hello @userName!</a>
         </li>
         <li class="nav-item">
-            <form class="form-inline" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })" method="post">
-                <button type="submit" class="nav-link btn btn-link text-dark">Logout</button>
+            <a class="nav-link text-dark" asp-page="/Account/Manage/ChangePassword" title="Change Password">Change Password</a>
+        </li>
+        <li class="nav-item">
+            <form id="logoutForm" class="form-inline" asp-page="/Account/Logout" asp-route-returnUrl="@Url.Page("/Index", new { area = "" })" method="post">
+                <button id="logout" type="submit" class="nav-link btn btn-link text-dark border-0">Logout</button>
             </form>
         </li>
     }
     else
     {
         <li class="nav-item">
-            <a class="nav-link text-dark" asp-page="/Account/Register">Register</a>
+            <a class="nav-link text-dark" id="register" asp-page="/Account/Register">Register</a>
         </li>
         <li class="nav-item">
-            <a class="nav-link text-dark" asp-page="/Account/Login">Login</a>
+            <a class="nav-link text-dark" id="login" asp-page="/Account/Login">Login</a>
         </li>
     }
 </ul>

--- a/src/Presentation/FitnessTracker.WebUI/Program.cs
+++ b/src/Presentation/FitnessTracker.WebUI/Program.cs
@@ -102,6 +102,17 @@ builder.Services.AddHttpClient("ApiClient", client =>
     client.DefaultRequestHeaders.Add("Accept", "application/json");
 });
 
+builder.Services.AddRazorPages(options =>
+{
+    options.Conventions.AllowAnonymousToPage("/Account/Login");
+    options.Conventions.AllowAnonymousToPage("/Account/Register");
+    options.Conventions.AllowAnonymousToPage("/Account/ConfirmEmail");
+    options.Conventions.AllowAnonymousToPage("/Account/RegistrationConfirmation");
+    options.Conventions.AllowAnonymousToPage("/Account/ResendEmailConfirmation");
+    options.Conventions.AllowAnonymousToPage("/Account/ForgotPassword");   
+    options.Conventions.AllowAnonymousToPage("/Account/ResetPassword");  
+});
+
 builder.Services.AddControllers();
 builder.Services.AddRazorPages(options =>
 {


### PR DESCRIPTION
I. Change Password (For Authenticated Users)
Goal: Allow currently logged-in users to change their password by providing their current password and a new password.
Workflow:
UI (Razor Page - /Account/Manage/ChangePassword):
A new Razor Page is provided under account management, accessible only to authenticated users ([Authorize] attribute on PageModel).
The page presents a form for "Current Password," "New Password," and "Confirm New Password."
Client-side validation (DataAnnotations on ChangePasswordDto) checks for required fields, password length, and matching new passwords.
On submission, the PageModel (ChangePassword.cshtml.cs) makes an authenticated POST request to the /api/account/change-password endpoint. The JWT token (from the api_auth_token cookie) is read and manually added to the Authorization: Bearer <token> header for this API call.
API Endpoint (AccountController.cs - POST /api/account/change-password):
This endpoint is protected by [Authorize(AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)].
It receives the ChangePasswordDto.
Retrieves the current userId from the JWT claims.
Delegates the core logic to _userService.ChangePasswordAsync(userId, dto).
Inspects the Result object returned by the service and maps it to an appropriate IActionResult (e.g., Ok(), BadRequest() for validation errors like "PasswordMismatch", NotFound() if user somehow doesn't exist, StatusCode(500) for unexpected errors).
Application Service (UserService.cs - ChangePasswordAsync):
Receives userId and ChangePasswordDto.
Uses UserManager<ApplicationUser>.FindByIdAsync(userId) to retrieve the user.
Calls UserManager<ApplicationUser>.ChangePasswordAsync(user, dto.CurrentPassword, dto.NewPassword). This Identity method handles:
Verifying the dto.CurrentPassword against the user's stored password hash.
Validating the dto.NewPassword against configured password complexity policies.
Updating the user's PasswordHash if all checks pass.
If successful, it calls UserManager<ApplicationUser>.UpdateSecurityStampAsync(user) to invalidate any other active sessions for the user (good security practice).
Returns a Result.Success() or Result.ValidationFailed(...) (e.g., for PasswordMismatch or policy violations) or Result.NotFound(). Unexpected exceptions are wrapped in Result.Unexpected().
UI Feedback: The ChangePassword.cshtml.cs PageModel displays a success or error message based on the API response.
II. Forgot Password & Reset Password Flow
Goal: Allow users who have forgotten their password to securely reset it via an email link.
Workflow - Step 1: Forgot Password (Requesting Reset Link)
UI (Razor Page - /Account/ForgotPassword):
A new, anonymously accessible Razor Page.
Presents a form for the user to enter their email address.
On submission, the PageModel (ForgotPassword.cshtml.cs) makes a POST request to /api/account/forgot-password.
API Endpoint (AccountController.cs - POST /api/account/forgot-password):
This endpoint is anonymously accessible.
Receives ForgotPasswordDto (containing the email).
Delegates to _userService.GeneratePasswordResetTokenAsync(email).
Privacy Consideration: Regardless of whether the user/email exists or if the service call is fully successful, this API endpoint is designed to always return an HTTP 200 OK with a generic message (e.g., "If an account with that email exists, a password reset link has been sent...") This prevents email enumeration attacks.
If the service successfully returns a user and a raw password reset token:
The token is URL-safe Base64 encoded using WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(rawToken)).
A callback URL to /Account/ResetPassword is generated, including the encoded token and the user's email as query parameters.
_emailSender.SendEmailAsync is called to send the reset link to the user's email. Any exceptions during email sending are caught and suppressed from the client response (but would be logged if logging were enabled) to maintain the privacy-preserving generic response.
Application Service (UserService.cs - GeneratePasswordResetTokenAsync):
Receives the email.
Uses UserManager<ApplicationUser>.FindByEmailAsync(email) to find the user.
If the user is not found, it returns a Result.NotFound(). The controller handles this by still sending a generic success message to the client.
If the user is found, it calls UserManager<ApplicationUser>.GeneratePasswordResetTokenAsync(user) to generate a raw password reset token.
Returns Result.Success((user, rawToken)).
UI Feedback: The ForgotPassword.cshtml.cs PageModel displays the generic success message received from the API.
Workflow - Step 2: Reset Password (Using the Link)
User Action: The user receives the password reset email and clicks the unique link.
UI (Razor Page - /Account/ResetPassword):
This new, anonymously accessible Razor Page is loaded.
The OnGet method of ResetPassword.cshtml.cs captures the URL-encoded token and email from the query string and populates the Input model (which includes hidden fields for token and email).
The page presents a form for "New Password" and "Confirm New Password." The user's email is typically displayed (read-only).
On submission, the PageModel (ResetPassword.cshtml.cs):
Crucially decodes the URL-safe Base64 token from Input.Token back to its raw form using Encoding.UTF8.GetString(WebEncoders.Base64UrlDecode(Input.Token)).
Creates a ResetPasswordDto containing the email, new password, and the decoded (raw) token.
Makes a POST request to /api/account/reset-password with this DTO.
API Endpoint (AccountController.cs - POST /api/account/reset-password):
This endpoint is anonymously accessible.
Receives the ResetPasswordDto (containing email, new password, and the raw/decoded token).
Delegates to _userService.ResetPasswordAsync(dto).
Inspects the Result from the service and maps it to Ok(), BadRequest() (e.g., for "InvalidToken" or password policy violations), or StatusCode(500).
Application Service (UserService.cs - ResetPasswordAsync):
Receives ResetPasswordDto.
Uses UserManager<ApplicationUser>.FindByEmailAsync(dto.Email) to retrieve the user.
If user not found, returns Result.NotFound().
Calls UserManager<ApplicationUser>.ResetPasswordAsync(user, dto.Token, dto.Password) using the raw (decoded) token. This Identity method:
Validates the token against the user and its purpose.
Validates the new password against complexity policies.
Updates the user's PasswordHash if all checks pass.
If successful, it calls UserManager<ApplicationUser>.UpdateSecurityStampAsync(user) to invalidate other active sessions.
Returns Result.Success() or Result.ValidationFailed(...) (e.g., for "InvalidToken" or policy violations).
UI Feedback: The ResetPassword.cshtml.cs PageModel displays a success message ("Your password has been reset.") or error messages based on the API response. On success, the form is typically hidden.
Security Considerations Handled:
Password Hashing: ASP.NET Core Identity handles secure hashing and storage of passwords.
Token Generation & Validation: Identity's token providers generate time-limited, purpose-specific tokens for email confirmation and password reset.
URL-Safe Tokens: Tokens are URL-safe Base64 encoded for inclusion in email links and decoded before use.
Security Stamp: Updated after password changes/resets to invalidate existing login sessions.
Privacy in Forgot Password: The API consistently returns a generic success message for the "forgot password" request step to prevent attackers from enumerating valid email addresses.
This implementation provides a secure and user-friendly way for users to manage their passwords.